### PR TITLE
feat: add company flag and dark auth pages

### DIFF
--- a/pointer-landing-template/app/(auth)/sign-in/page.tsx
+++ b/pointer-landing-template/app/(auth)/sign-in/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Fingerprint } from "lucide-react";
 
 export default function SignInPage() {
   const [email, setEmail] = useState("");
@@ -20,12 +21,15 @@ export default function SignInPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center p-6">
+    <div className="flex min-h-screen items-center justify-center p-6 bg-gray-950 text-white">
       <div className="w-full max-w-sm">
-        <Card>
-          <CardHeader className="space-y-1">
-            <CardTitle className="text-2xl">Sign In</CardTitle>
-            <CardDescription>Enter your email and password</CardDescription>
+        <Card className="bg-gray-900">
+          <CardHeader className="space-y-4 text-center">
+            <Fingerprint className="mx-auto h-12 w-12 text-primary" />
+            <div className="space-y-1">
+              <CardTitle className="text-2xl">Sign In</CardTitle>
+              <CardDescription>Enter your email and password</CardDescription>
+            </div>
           </CardHeader>
           <CardContent>
             <form onSubmit={onSubmit} className="grid gap-4">

--- a/pointer-landing-template/app/(auth)/sign-up/page.tsx
+++ b/pointer-landing-template/app/(auth)/sign-up/page.tsx
@@ -5,12 +5,14 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 
 export default function SignUpPage() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [isCompany, setIsCompany] = useState(false);
   const router = useRouter();
 
   async function onSubmit(e: React.FormEvent) {
@@ -18,15 +20,15 @@ export default function SignUpPage() {
     const res = await fetch("/api/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, email, password }),
+      body: JSON.stringify({ name, email, password, isCompany }),
     });
     if (res.ok) router.push("/sign-in");
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center p-6">
+    <div className="flex min-h-screen items-center justify-center p-6 bg-gray-950 text-white">
       <div className="w-full max-w-sm">
-        <Card>
+        <Card className="bg-gray-900">
           <CardHeader className="space-y-1">
             <CardTitle className="text-2xl">Create an account</CardTitle>
             <CardDescription>Enter your details to sign up</CardDescription>
@@ -50,6 +52,10 @@ export default function SignUpPage() {
                   onChange={(e) => setPassword(e.target.value)}
                   required
                 />
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox id="isCompany" checked={isCompany} onCheckedChange={(checked) => setIsCompany(!!checked)} />
+                <Label htmlFor="isCompany">Register as a company</Label>
               </div>
               <Button type="submit" className="w-full">
                 Sign Up

--- a/pointer-landing-template/app/api/auth/register/route.ts
+++ b/pointer-landing-template/app/api/auth/register/route.ts
@@ -5,7 +5,7 @@ import { users } from "@/db/schema";
 import { eq } from "drizzle-orm";
 
 export async function POST(req: Request) {
-  const { email, password, name } = await req.json();
+  const { email, password, name, isCompany } = await req.json();
   if (!email || !password) {
     return NextResponse.json({ error: "Email and password required" }, { status: 400 });
   }
@@ -14,6 +14,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Email already in use" }, { status: 400 });
   }
   const hashedPassword = createHash("sha256").update(password).digest("hex");
-  await db.insert(users).values({ email, name: name ?? null, hashedPassword });
+  await db
+    .insert(users)
+    .values({ email, name: name ?? null, hashedPassword, isCompany: !!isCompany });
   return NextResponse.json({ success: true });
 }

--- a/pointer-landing-template/db/schema.ts
+++ b/pointer-landing-template/db/schema.ts
@@ -10,6 +10,7 @@ export const users = pgTable("users", {
   hashedPassword: text("hashed_password"),
   createdAt: timestamp("created_at").defaultNow(),
   isAdmin: boolean("is_admin").default(false),
+  isCompany: boolean("is_company").default(false),
 });
 
 export const accounts = pgTable("accounts", {

--- a/pointer-landing-template/lib/auth.ts
+++ b/pointer-landing-template/lib/auth.ts
@@ -17,7 +17,13 @@ export const authOptions: NextAuthOptions = {
         if (!user?.hashedPassword) return null;
         const hashed = createHash("sha256").update(creds.password).digest("hex");
         return hashed === user.hashedPassword
-          ? { id: user.id, name: user.name ?? undefined, email: user.email, image: user.image ?? undefined }
+          ? {
+              id: user.id,
+              name: user.name ?? undefined,
+              email: user.email,
+              image: user.image ?? undefined,
+              isCompany: user.isCompany ?? undefined,
+            }
           : null;
       },
     }),
@@ -27,7 +33,7 @@ export const authOptions: NextAuthOptions = {
       if (user?.email) {
         const existing = await db.select().from(users).where(eq(users.email, user.email));
         if (existing.length === 0) {
-          await db.insert(users).values({ email: user.email, name: user.name ?? null });
+          await db.insert(users).values({ email: user.email, name: user.name ?? null, isCompany: false });
         }
       }
       return true;


### PR DESCRIPTION
## Summary
- add `isCompany` flag to user table and registration API
- support company registration with checkbox
- apply dark theme and fingerprint icon to sign-in page

## Testing
- `npm run lint` *(prompts for ESLint config, cannot run)*
- `npm run build` *(fails: Can't resolve 'next-auth', 'drizzle-orm')*

------
https://chatgpt.com/codex/tasks/task_e_68c516554970832f87c728ffac7d9f49