### PR TITLE
feat(auth): cross link sign-in and sign-up pages

### DIFF
--- a/pointer-landing-template/app/(auth)/sign-in/page.tsx
+++ b/pointer-landing-template/app/(auth)/sign-in/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { Button } from "@/components/ui/button";
@@ -51,6 +52,9 @@ export default function SignInPage() {
                 Sign In
               </Button>
             </form>
+            <div className="mt-4 text-sm text-center">
+              Don\'t have an account? <Link href="/sign-up" className="underline">Sign Up</Link>
+            </div>
           </CardContent>
         </Card>
       </div>

--- a/pointer-landing-template/app/(auth)/sign-up/page.tsx
+++ b/pointer-landing-template/app/(auth)/sign-up/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -61,6 +62,9 @@ export default function SignUpPage() {
                 Sign Up
               </Button>
             </form>
+            <div className="mt-4 text-sm text-center">
+              Already have an account? <Link href="/sign-in" className="underline">Sign In</Link>
+            </div>
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- add bottom links to switch between sign-in and sign-up pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c51d358860832fb00116ec8aaf02bf