### PR TITLE
Refactor dashboard to align with landing style

### DIFF
--- a/pointer-landing-template/components/kokonutui/content.tsx
+++ b/pointer-landing-template/components/kokonutui/content.tsx
@@ -1,39 +1,20 @@
-import { Calendar, CreditCard, Wallet } from "lucide-react"
-import List01 from "./list-01"
-import List02 from "./list-02"
-import List03 from "./list-03"
 
-export default function () {
+import TrustEcosystemSection from "@/components/trust-ecosystem-section"
+import { SocialProof } from "@/components/social-proof"
+
+export default function Content() {
   return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="bg-white dark:bg-[#0F0F12] rounded-xl p-6 flex flex-col border border-gray-200 dark:border-[#1F1F23]">
-          <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4 text-left flex items-center gap-2 ">
-            <Wallet className="w-3.5 h-3.5 text-zinc-900 dark:text-zinc-50" />
-            Accounts
-          </h2>
-          <div className="flex-1">
-            <List01 className="h-full" />
-          </div>
-        </div>
-        <div className="bg-white dark:bg-[#0F0F12] rounded-xl p-6 flex flex-col border border-gray-200 dark:border-[#1F1F23]">
-          <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4 text-left flex items-center gap-2">
-            <CreditCard className="w-3.5 h-3.5 text-zinc-900 dark:text-zinc-50" />
-            Recent Transactions
-          </h2>
-          <div className="flex-1">
-            <List02 className="h-full" />
-          </div>
-        </div>
-      </div>
-
-      <div className="bg-white dark:bg-[#0F0F12] rounded-xl p-6 flex flex-col items-start justify-start border border-gray-200 dark:border-[#1F1F23]">
-        <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4 text-left flex items-center gap-2">
-          <Calendar className="w-3.5 h-3.5 text-zinc-900 dark:text-zinc-50" />
-          Upcoming Events
-        </h2>
-        <List03 />
-      </div>
+    <div className="space-y-16">
+      <section className="text-center space-y-4">
+        <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white">
+          Ensure trust and prevent fraud with verifiable, soulbound credentials for Universities.
+        </h1>
+        <p className="text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
+          Build transparent reputation networks and protect against fake institutions through community-driven reporting. Empower HR teams with reliable CVs and enable secure document storage across healthcare, logistics, and beyond — all while keeping ownership of data in the hands of individuals, not corporations.
+        </p>
+      </section>
+      <SocialProof />
+      <TrustEcosystemSection />
     </div>
   )
 }

--- a/pointer-landing-template/components/kokonutui/sidebar.tsx
+++ b/pointer-landing-template/components/kokonutui/sidebar.tsx
@@ -19,7 +19,6 @@ import {
 import { Home } from "lucide-react"
 import Link from "next/link"
 import { useState } from "react"
-import Image from "next/image"
 
 export default function Sidebar() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
@@ -67,30 +66,12 @@ export default function Sidebar() {
       >
         <div className="h-full flex flex-col">
           <Link
-            href="https://kokonutui.com/"
-            target="_blank"
-            rel="noopener noreferrer"
+            href="/"
             className="h-16 px-6 flex items-center border-b border-gray-200 dark:border-[#1F1F23]"
           >
-            <div className="flex items-center gap-3">
-              <Image
-                src="https://kokonutui.com/logo.svg"
-                alt="Acme"
-                width={32}
-                height={32}
-                className="flex-shrink-0 hidden dark:block"
-              />
-              <Image
-                src="https://kokonutui.com/logo-black.svg"
-                alt="Acme"
-                width={32}
-                height={32}
-                className="flex-shrink-0 block dark:hidden"
-              />
-              <span className="text-lg font-semibold hover:cursor-pointer text-gray-900 dark:text-white">
-                KokonutUI
-              </span>
-            </div>
+            <span className="text-lg font-semibold hover:cursor-pointer text-gray-900 dark:text-white">
+              Legacy
+            </span>
           </Link>
 
           <div className="flex-1 overflow-y-auto py-4 px-4">

--- a/pointer-landing-template/components/kokonutui/top-nav.tsx
+++ b/pointer-landing-template/components/kokonutui/top-nav.tsx
@@ -18,8 +18,8 @@ interface BreadcrumbItem {
 
 export default function TopNav() {
   const breadcrumbs: BreadcrumbItem[] = [
-    { label: "kokonutUI", href: "#" },
-    { label: "dashboard", href: "#" },
+    { label: "Legacy", href: "/" },
+    { label: "Dashboard", href: "#" },
   ]
 
   return (


### PR DESCRIPTION
## Summary
- Replace finance placeholder dashboard with hero text, collaboration logos, and trust ecosystem section.
- Update top navigation breadcrumbs to reflect Legacy branding.
- Simplify sidebar branding to link back to the home page.

## Testing
- `npm test` *(fails: package missing in lockfile)*
- `npm test` in pointer-landing-template *(fails: missing script)*
- `npm run lint` in pointer-landing-template *(prompts for ESLint configuration)*
- `npm run build` in pointer-landing-template *(fails: cannot fetch fonts and missing @clerk/nextjs module)*

------
https://chatgpt.com/codex/tasks/task_e_68c56271ea88832f99eb2a7ddb1aec7b