### PR TITLE
feat: add Solana wallet linking and finance scaffolding

### DIFF
--- a/pointer-landing-template/app/api/link-wallet/route.ts
+++ b/pointer-landing-template/app/api/link-wallet/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { auth, clerkClient } from '@clerk/nextjs/server'
+import bs58 from 'bs58'
+import nacl from 'tweetnacl'
+
+export async function POST(req: Request) {
+  const { userId } = auth()
+  if (!userId) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const { publicKey, signature, nonce } = await req.json()
+  const storedNonce = cookies().get('nonce')?.value
+  if (!storedNonce || storedNonce !== nonce) {
+    return new NextResponse('Invalid nonce', { status: 400 })
+  }
+
+  const message = new TextEncoder().encode(nonce)
+  const isValid = nacl.sign.detached.verify(
+    message,
+    bs58.decode(signature),
+    bs58.decode(publicKey)
+  )
+  if (!isValid) {
+    return new NextResponse('Invalid signature', { status: 400 })
+  }
+
+  await clerkClient.users.updateUser(userId, {
+    publicMetadata: {
+      wallets: {
+        solana: {
+          address: publicKey,
+          verifiedAt: new Date().toISOString(),
+        },
+      },
+    },
+  })
+  // TODO: record WALLET_LINKED in transactions table
+  cookies().delete('nonce')
+  return NextResponse.json({ linked: true })
+}

--- a/pointer-landing-template/app/api/nonce/route.ts
+++ b/pointer-landing-template/app/api/nonce/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import crypto from 'crypto'
+
+export async function GET() {
+  const nonce = crypto.randomBytes(16).toString('hex')
+  cookies().set('nonce', nonce, { httpOnly: true, sameSite: 'strict' })
+  return NextResponse.json({ nonce })
+}

--- a/pointer-landing-template/app/finance/invoices/page.tsx
+++ b/pointer-landing-template/app/finance/invoices/page.tsx
@@ -1,0 +1,11 @@
+import Layout from "@/components/kokonutui/layout"
+import InvoicesTable from "@/components/finance/invoices-table"
+
+export default function InvoicesPage() {
+  return (
+    <Layout>
+      <h1 className="mb-4 text-xl font-semibold text-gray-100">Invoices</h1>
+      <InvoicesTable />
+    </Layout>
+  )
+}

--- a/pointer-landing-template/app/finance/payments/page.tsx
+++ b/pointer-landing-template/app/finance/payments/page.tsx
@@ -1,0 +1,11 @@
+import Layout from "@/components/kokonutui/layout"
+import PaymentsTable from "@/components/finance/payments-table"
+
+export default function PaymentsPage() {
+  return (
+    <Layout>
+      <h1 className="mb-4 text-xl font-semibold text-gray-100">Payments</h1>
+      <PaymentsTable />
+    </Layout>
+  )
+}

--- a/pointer-landing-template/app/finance/transactions/page.tsx
+++ b/pointer-landing-template/app/finance/transactions/page.tsx
@@ -1,0 +1,11 @@
+import Layout from "@/components/kokonutui/layout"
+import TransactionsTable from "@/components/finance/transactions-table"
+
+export default function TransactionsPage() {
+  return (
+    <Layout>
+      <h1 className="mb-4 text-xl font-semibold text-gray-100">Transactions</h1>
+      <TransactionsTable />
+    </Layout>
+  )
+}

--- a/pointer-landing-template/app/layout.tsx
+++ b/pointer-landing-template/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
     <ClerkProvider>
       <html lang="en">
         <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-          <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+          <ThemeProvider attribute="class" defaultTheme="dark" disableTransitionOnChange>
           {children}
           </ThemeProvider>
         </body>

--- a/pointer-landing-template/components/connect-wallet.tsx
+++ b/pointer-landing-template/components/connect-wallet.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { ConnectionProvider, WalletProvider, useWallet } from '@solana/wallet-adapter-react'
+import { PhantomWalletAdapter } from '@solana/wallet-adapter-wallets'
+import { WalletAdapterNetwork } from '@solana/wallet-adapter-base'
+import { clusterApiUrl } from '@solana/web3.js'
+import bs58 from 'bs58'
+
+function WalletButton() {
+  const { connected, publicKey, connect, signMessage } = useWallet()
+  const [status, setStatus] = useState<string>('')
+
+  const handleConnect = async () => {
+    try {
+      await connect()
+    } catch (err) {
+      console.error('Connect failed', err)
+    }
+  }
+
+  const handleLink = async () => {
+    if (!publicKey || !signMessage) return
+    try {
+      const nonceRes = await fetch('/api/nonce')
+      const { nonce } = await nonceRes.json()
+      const message = new TextEncoder().encode(nonce)
+      const signature = bs58.encode(await signMessage(message))
+      await fetch('/api/link-wallet', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ publicKey: publicKey.toBase58(), signature, nonce })
+      })
+      setStatus('Wallet linked ✅')
+    } catch (err) {
+      console.error('Link failed', err)
+    }
+  }
+
+  if (!connected) {
+    return (
+      <button onClick={handleConnect} className="bg-[#6c47ff] text-white rounded-md px-3 py-2 text-sm">
+        Connect Phantom
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <button onClick={handleLink} className="bg-[#6c47ff] text-white rounded-md px-3 py-2 text-sm">
+        Link Wallet
+      </button>
+      {status && <span className="text-xs text-green-500">{status}</span>}
+    </div>
+  )
+}
+
+export default function ConnectWallet() {
+  const network = WalletAdapterNetwork.Devnet
+  const endpoint = useMemo(() => clusterApiUrl(network), [network])
+  const wallets = useMemo(() => [new PhantomWalletAdapter()], [])
+
+  return (
+    <ConnectionProvider endpoint={endpoint}>
+      <WalletProvider wallets={wallets} autoConnect>
+        <WalletButton />
+      </WalletProvider>
+    </ConnectionProvider>
+  )
+}

--- a/pointer-landing-template/components/finance/invoices-table.tsx
+++ b/pointer-landing-template/components/finance/invoices-table.tsx
@@ -1,0 +1,44 @@
+export interface Invoice {
+  id: string
+  asset: string
+  amountUsdc: number
+  status: string
+  dueDate: string
+}
+
+const sample: Invoice[] = [
+  {
+    id: "1",
+    asset: "Demo Asset",
+    amountUsdc: 100,
+    status: "SENT",
+    dueDate: "2024-02-01",
+  },
+]
+
+export default function InvoicesTable() {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-800 text-gray-400">
+            <th className="px-2 py-1 text-left">Asset</th>
+            <th className="px-2 py-1 text-left">Amount (USDC)</th>
+            <th className="px-2 py-1 text-left">Status</th>
+            <th className="px-2 py-1 text-left">Due</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sample.map((inv) => (
+            <tr key={inv.id} className="border-b border-gray-800 text-gray-200">
+              <td className="px-2 py-1">{inv.asset}</td>
+              <td className="px-2 py-1">{inv.amountUsdc}</td>
+              <td className="px-2 py-1">{inv.status}</td>
+              <td className="px-2 py-1">{inv.dueDate}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/pointer-landing-template/components/finance/payments-table.tsx
+++ b/pointer-landing-template/components/finance/payments-table.tsx
@@ -1,0 +1,44 @@
+export interface Payment {
+  id: string
+  invoiceId: string
+  payer: string
+  amountUsdc: number
+  status: string
+}
+
+const sample: Payment[] = [
+  {
+    id: "1",
+    invoiceId: "1",
+    payer: "Fh8s...9pQ",
+    amountUsdc: 100,
+    status: "PAID",
+  },
+]
+
+export default function PaymentsTable() {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-800 text-gray-400">
+            <th className="px-2 py-1 text-left">Invoice</th>
+            <th className="px-2 py-1 text-left">Payer</th>
+            <th className="px-2 py-1 text-left">Amount (USDC)</th>
+            <th className="px-2 py-1 text-left">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sample.map((pmt) => (
+            <tr key={pmt.id} className="border-b border-gray-800 text-gray-200">
+              <td className="px-2 py-1">{pmt.invoiceId}</td>
+              <td className="px-2 py-1">{pmt.payer}</td>
+              <td className="px-2 py-1">{pmt.amountUsdc}</td>
+              <td className="px-2 py-1">{pmt.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/pointer-landing-template/components/finance/transactions-table.tsx
+++ b/pointer-landing-template/components/finance/transactions-table.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link"
+
+export interface Transaction {
+  id: string
+  type: string
+  tokenMint: string
+  amount: number
+  signature?: string
+  createdAt: string
+}
+
+const sample: Transaction[] = [
+  {
+    id: "1",
+    type: "WALLET_LINKED",
+    tokenMint: "-",
+    amount: 0,
+    signature: "3gL9dQ9k8WxFZqj",
+    createdAt: "2024-01-01",
+  },
+]
+
+export default function TransactionsTable() {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-800 text-gray-400">
+            <th className="px-2 py-1 text-left">Type</th>
+            <th className="px-2 py-1 text-left">Token</th>
+            <th className="px-2 py-1 text-left">Amount</th>
+            <th className="px-2 py-1 text-left">Signature</th>
+            <th className="px-2 py-1 text-left">Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sample.map((tx) => (
+            <tr key={tx.id} className="border-b border-gray-800 text-gray-200">
+              <td className="px-2 py-1">{tx.type}</td>
+              <td className="px-2 py-1">{tx.tokenMint}</td>
+              <td className="px-2 py-1">{tx.amount}</td>
+              <td className="px-2 py-1">
+                {tx.signature ? (
+                  <Link
+                    href={`https://explorer.solana.com/tx/${tx.signature}?cluster=devnet`}
+                    target="_blank"
+                    className="text-indigo-400 hover:underline"
+                  >
+                    {tx.signature.slice(0, 8)}...
+                  </Link>
+                ) : (
+                  "-"
+                )}
+              </td>
+              <td className="px-2 py-1">{tx.createdAt}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/pointer-landing-template/components/kokonutui/sidebar.tsx
+++ b/pointer-landing-template/components/kokonutui/sidebar.tsx
@@ -120,13 +120,13 @@ export default function Sidebar() {
                   Finance
                 </div>
                 <div className="space-y-1">
-                  <NavItem href="#" icon={Wallet}>
+                  <NavItem href="/finance/transactions" icon={Wallet}>
                     Transactions
                   </NavItem>
-                  <NavItem href="#" icon={Receipt}>
+                  <NavItem href="/finance/invoices" icon={Receipt}>
                     Invoices
                   </NavItem>
-                  <NavItem href="#" icon={CreditCard}>
+                  <NavItem href="/finance/payments" icon={CreditCard}>
                     Payments
                   </NavItem>
                 </div>

--- a/pointer-landing-template/components/kokonutui/top-nav.tsx
+++ b/pointer-landing-template/components/kokonutui/top-nav.tsx
@@ -2,7 +2,7 @@
 
 import { Bell, ChevronRight } from "lucide-react"
 import Link from "next/link"
-import { ThemeToggle } from "@/components/theme-toggle"
+import ConnectWallet from "@/components/connect-wallet"
 import {
   SignInButton,
   SignUpButton,
@@ -50,7 +50,7 @@ export default function TopNav() {
           <Bell className="h-4 w-4 sm:h-5 sm:w-5 text-gray-600 dark:text-gray-300" />
         </button>
 
-        <ThemeToggle />
+        <ConnectWallet />
 
         <SignedOut>
           <SignInButton />

--- a/pointer-landing-template/package.json
+++ b/pointer-landing-template/package.json
@@ -64,7 +64,13 @@
     "sonner": "^1.7.1",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "@solana/web3.js": "^1.95.3",
+    "@solana/wallet-adapter-react": "^0.17.8",
+    "@solana/wallet-adapter-wallets": "^0.19.17",
+    "@solana/wallet-adapter-base": "^0.10.7",
+    "bs58": "^5.0.0",
+    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Summary
- enforce dark theme across app
- add Phantom wallet connect component and API routes for nonce & link wallet
- scaffold finance section with transactions, invoices and payments tables

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c56c939de0832f9625e72fe79cae2f